### PR TITLE
persist user info with localStorage & cookie vaidation

### DIFF
--- a/src/api/githubUser.ts
+++ b/src/api/githubUser.ts
@@ -1,6 +1,9 @@
 import { GITHUB_USER_INFO } from 'constants/api.constant';
 import { AUTHORIZATION_COOKIE_NAME, setCookie } from 'utils/cookie.util';
 import { checkError } from 'utils/apiHandlers.util';
+import { STORAGE_KEYS } from 'constants/storage.constant';
+import { setToLocalStorage } from 'utils/storage.util';
+
 type UserInfo = {
   repo: {
     name: string;
@@ -41,6 +44,7 @@ export const getUserGithubInfo = async (code: string): Promise<UserInfo | null> 
 
     // TODO: change the cookie expiration time to appropriate value
     setCookie(AUTHORIZATION_COOKIE_NAME, authToken, 60 * 60 * 24 * 1); // 1 day in seconds
+    setToLocalStorage(STORAGE_KEYS.USER_INFO, JSON.stringify(data.data));
 
     return data.data;
   } catch (error) {

--- a/src/components/FilePreview/previews/previews.module.css
+++ b/src/components/FilePreview/previews/previews.module.css
@@ -44,6 +44,7 @@
   font-family: monospace;
   white-space: pre-wrap;
   word-break: break-word;
+  max-height: 40vh;
 }
 
 .imagePreview {

--- a/src/constants/storage.constant.ts
+++ b/src/constants/storage.constant.ts
@@ -1,0 +1,3 @@
+export const STORAGE_KEYS = {
+  USER_INFO: 'userInfo',
+};

--- a/src/hooks/useGithubAuthListener.ts
+++ b/src/hooks/useGithubAuthListener.ts
@@ -2,6 +2,10 @@ import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { getUserGithubInfo } from 'api/githubUser';
 import { useGithubUserInfoStore } from 'store/GithubUserInfoStore';
+import { STORAGE_KEYS } from 'constants/storage.constant';
+import { getFromLocalStorage, removeFromLocalStorage } from 'utils/storage.util';
+import { AUTHORIZATION_COOKIE_NAME } from 'utils/cookie.util';
+import { getCookie } from 'utils/cookie.util';
 
 export const useGithubAuthListener = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -9,6 +13,16 @@ export const useGithubAuthListener = () => {
   const { setUserInfo } = useGithubUserInfoStore();
 
   useEffect(() => {
+    const cookie = getCookie(AUTHORIZATION_COOKIE_NAME);
+    const userInfo = getFromLocalStorage(STORAGE_KEYS.USER_INFO);
+
+    if (cookie && userInfo) {
+      setUserInfo(JSON.parse(userInfo));
+      return;
+    } else {
+      removeFromLocalStorage(STORAGE_KEYS.USER_INFO);
+    }
+
     const allParams = Object.fromEntries(searchParams.entries());
     const { code, ...restParams } = allParams;
 

--- a/src/utils/apiHandlers.util.ts
+++ b/src/utils/apiHandlers.util.ts
@@ -1,7 +1,10 @@
+import { deleteCookie, AUTHORIZATION_COOKIE_NAME } from 'utils/cookie.util';
+
 export const checkError = async (response: Response) => {
   if (response.ok) return;
 
   if (response.status === 401) {
+    deleteCookie(AUTHORIZATION_COOKIE_NAME);
     throw new Error('User not logged in or session expired');
   }
 

--- a/src/utils/storage.util.ts
+++ b/src/utils/storage.util.ts
@@ -1,0 +1,24 @@
+export const getFromLocalStorage = (key: string) => {
+  try {
+    return localStorage.getItem(key);
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};
+
+export const setToLocalStorage = (key: string, value: string) => {
+  try {
+    localStorage.setItem(key, value);
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const removeFromLocalStorage = (key: string) => {
+  try {
+    localStorage.removeItem(key);
+  } catch (error) {
+    console.error(error);
+  }
+};


### PR DESCRIPTION
## Description
- persist user info with localStorage & cookie vaidation
  ```ts
  export const STORAGE_KEYS = {
    USER_INFO: 'userInfo',
  };
- Storage utils at `src/utils/storage.util.ts`
  - `getFromLocalStorage`, `setToLocalStorage`, `removeFromLocalStorage`
- If cookie present, data in localStorage present, assign to userInfo.

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules 